### PR TITLE
[BugFix] Distinct and filter string array

### DIFF
--- a/Jellyfin.Plugin.MetaTube/Providers/MovieProvider.cs
+++ b/Jellyfin.Plugin.MetaTube/Providers/MovieProvider.cs
@@ -72,6 +72,11 @@ public class MovieProvider : BaseProvider, IRemoteMetadataProvider<Movie, MovieI
         if (Configuration.TranslationMode != TranslationMode.Disabled)
             await TranslateMovieInfo(m, info.MetadataLanguage, cancellationToken);
 
+        // Distinct and clean blank list
+        m.Genres = m.Genres?.Where(x => !string.IsNullOrWhiteSpace(x)).Distinct().ToArray() ?? Array.Empty<string>();
+        m.Actors = m.Actors?.Where(x => !string.IsNullOrWhiteSpace(x)).Distinct().ToArray() ?? Array.Empty<string>();
+        m.PreviewImages = m.PreviewImages?.Where(x => !string.IsNullOrWhiteSpace(x)).Distinct().ToArray() ?? Array.Empty<string>();
+
         // Build parameters.
         var parameters = new Dictionary<string, string>
         {


### PR DESCRIPTION
1. Distinct and filter string array to prevent library refreshing being blocked.