### PR TITLE
[Feature] Jellyfin 10.9.0 related changes

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.x'
+          dotnet-version: '8.x'
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/Jellyfin.Plugin.MetaTube/Jellyfin.Plugin.MetaTube.csproj
+++ b/Jellyfin.Plugin.MetaTube/Jellyfin.Plugin.MetaTube.csproj
@@ -29,8 +29,8 @@
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)'=='Debug' or '$(Configuration)'=='Release'">
-        <PackageReference Include="Jellyfin.Controller" Version="10.8.0"/>
-        <PackageReference Include="Jellyfin.Model" Version="10.8.0"/>
+        <PackageReference Include="Jellyfin.Controller" Version="10.9.0"/>
+        <PackageReference Include="Jellyfin.Model" Version="10.9.0"/>
     </ItemGroup>
 
     <ItemGroup Condition="'$(Configuration)'=='Debug.Emby' or '$(Configuration)'=='Release.Emby'">

--- a/Jellyfin.Plugin.MetaTube/Jellyfin.Plugin.MetaTube.csproj
+++ b/Jellyfin.Plugin.MetaTube/Jellyfin.Plugin.MetaTube.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Configurations>Debug;Release;Debug.Emby;Release.Emby</Configurations>
         <Platforms>AnyCPU</Platforms>
@@ -18,6 +17,14 @@
         <PackageId>MetaTube</PackageId>
         <Company>MetaTube</Company>
         <Product>MetaTube</Product>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)'=='Debug' or '$(Configuration)'=='Release'">
+        <TargetFramework>net8.0</TargetFramework>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)'=='Debug.Emby' or '$(Configuration)'=='Release.Emby'">
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)'=='Debug.Emby' or '$(Configuration)'=='Release.Emby'">

--- a/Jellyfin.Plugin.MetaTube/Jellyfin.Plugin.MetaTube.csproj
+++ b/Jellyfin.Plugin.MetaTube/Jellyfin.Plugin.MetaTube.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Configurations>Debug;Release;Debug.Emby;Release.Emby</Configurations>
         <Platforms>AnyCPU</Platforms>

--- a/Jellyfin.Plugin.MetaTube/Providers/MovieProvider.cs
+++ b/Jellyfin.Plugin.MetaTube/Providers/MovieProvider.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.MetaTube.Configuration;
 using Jellyfin.Plugin.MetaTube.Extensions;
 using Jellyfin.Plugin.MetaTube.Metadata;
@@ -155,7 +156,7 @@ public class MovieProvider : BaseProvider, IRemoteMetadataProvider<Movie, MovieI
             result.AddPerson(new PersonInfo
             {
                 Name = m.Director,
-                Type = PersonType.Director
+                Type = PersonKind.Director
             });
 
         // Add actors.
@@ -164,7 +165,7 @@ public class MovieProvider : BaseProvider, IRemoteMetadataProvider<Movie, MovieI
             result.AddPerson(new PersonInfo
             {
                 Name = name,
-                Type = PersonType.Actor,
+                Type = PersonKind.Actor,
                 ImageUrl = await GetActorImageUrl(name, cancellationToken)
             });
         }

--- a/Jellyfin.Plugin.MetaTube/Providers/MovieProvider.cs
+++ b/Jellyfin.Plugin.MetaTube/Providers/MovieProvider.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.MetaTube.Configuration;
 using Jellyfin.Plugin.MetaTube.Extensions;
 using Jellyfin.Plugin.MetaTube.Metadata;
@@ -14,6 +13,7 @@ using MovieInfo = MediaBrowser.Controller.Providers.MovieInfo;
 using MediaBrowser.Model.Logging;
 
 #else
+using Jellyfin.Data.Enums;
 using Microsoft.Extensions.Logging;
 #endif
 
@@ -156,7 +156,11 @@ public class MovieProvider : BaseProvider, IRemoteMetadataProvider<Movie, MovieI
             result.AddPerson(new PersonInfo
             {
                 Name = m.Director,
+#if __EMBY__
+                Type = PersonType.Director
+#else
                 Type = PersonKind.Director
+#endif
             });
 
         // Add actors.
@@ -165,7 +169,11 @@ public class MovieProvider : BaseProvider, IRemoteMetadataProvider<Movie, MovieI
             result.AddPerson(new PersonInfo
             {
                 Name = name,
+#if __EMBY__
+                Type = PersonType.Actor,
+#else
                 Type = PersonKind.Actor,
+#endif
                 ImageUrl = await GetActorImageUrl(name, cancellationToken)
             });
         }

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ MetaTube Plugin for Jellyfin/Emby.
 
 ## Platforms
 
-[![Jellyfin](https://img.shields.io/static/v1?color=%2300A4DC&style=for-the-badge&label=Jellyfin&logo=jellyfin&message=10.8.x)](https://jellyfin.org/)
+[![Jellyfin](https://img.shields.io/static/v1?color=%2300A4DC&style=for-the-badge&label=Jellyfin&logo=jellyfin&message=10.9.x)](https://jellyfin.org/)
 [![Emby](https://img.shields.io/static/v1?color=%2352B54B&style=for-the-badge&label=Emby&logo=emby&message=4.8.x)](https://emby.media/)
 
 _NOTE: This project will only support stable versions._

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -44,7 +44,7 @@
 
 ## 平台
 
-[![Jellyfin](https://img.shields.io/static/v1?color=%2300A4DC&style=for-the-badge&label=Jellyfin&logo=jellyfin&message=10.8.x)](https://jellyfin.org/)
+[![Jellyfin](https://img.shields.io/static/v1?color=%2300A4DC&style=for-the-badge&label=Jellyfin&logo=jellyfin&message=10.9.x)](https://jellyfin.org/)
 [![Emby](https://img.shields.io/static/v1?color=%2352B54B&style=for-the-badge&label=Emby&logo=emby&message=4.8.x)](https://emby.media/)
 
 _注意：本项目仅支持 Jellyfin/Emby 稳定版。_

--- a/scripts/manifest.py
+++ b/scripts/manifest.py
@@ -15,7 +15,7 @@ def generate(filename, version):
     return {
         'checksum': md5sum(filename),
         'changelog': 'Auto Released by Actions',
-        'targetAbi': '10.8.0.0',
+        'targetAbi': '10.9.0.0',
         'sourceUrl': 'https://github.com/metatube-community/jellyfin-plugin-metatube/releases/download/'
                      f'v{version}/Jellyfin.MetaTube@v{version}.zip',
         'timestamp': datetime.now().strftime('%Y-%m-%dT%H:%M:%SZ'),


### PR DESCRIPTION
- Jellyfin 10.9.0 will use dotnet SDK 8.x
- Jellyfin change person definitions from raw strings to Enum values

Solves: #313 

PR applies changes to make it compatible with future 10.9.0 release.
Tested locally with default plugin settings.