### PR TITLE
Fix: handle empty trailer url in Jellyfin

### DIFF
--- a/Jellyfin.Plugin.MetaTube/Providers/MovieProvider.cs
+++ b/Jellyfin.Plugin.MetaTube/Providers/MovieProvider.cs
@@ -123,9 +123,11 @@ public class MovieProvider : BaseProvider, IRemoteMetadataProvider<Movie, MovieI
         result.Item.SetPid(Name, m.Provider, m.Id, pid.Position);
 
         // Set trailer url.
-        result.Item.SetTrailerUrl(!string.IsNullOrWhiteSpace(m.PreviewVideoUrl)
+        var trailerUrl = !string.IsNullOrWhiteSpace(m.PreviewVideoUrl)
             ? m.PreviewVideoUrl
-            : m.PreviewVideoHlsUrl);
+            : m.PreviewVideoHlsUrl;
+        if (!string.IsNullOrWhiteSpace(trailerUrl))
+            result.Item.SetTrailerUrl(trailerUrl);
 
         // Set community rating.
         if (Configuration.EnableRatings)


### PR DESCRIPTION
Fixes: https://github.com/metatube-community/jellyfin-plugin-metatube/issues/419