### PR TITLE
add custom translate config for deepl and openai

### DIFF
--- a/Jellyfin.Plugin.MetaTube/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.MetaTube/Configuration/PluginConfiguration.cs
@@ -245,4 +245,34 @@ public class PluginConfiguration : BasePluginConfiguration
     }
 
     private SubstitutionTable _genreSubstitutionTable;
+
+#if __EMBY__
+    [DisplayName("DeepLX api key")]
+    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.DeepLX)]
+#endif
+    public string DeepLXApiKey { get; set; } = string.Empty;
+
+#if __EMBY__
+    [DisplayName("DeepLX base url")]
+    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.DeepLX)]
+#endif
+    public string DeepLXBaseUrl { get; set; } = string.Empty;
+
+#if __EMBY__
+    [DisplayName("OpenAI api key")]
+    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAiX)]
+#endif
+    public string OpenAiXApiKey { get; set; } = string.Empty;
+
+#if __EMBY__
+    [DisplayName("OpenAI base url")]
+    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAiX)]
+#endif
+    public string OpenAiXBaseUrl { get; set; } = string.Empty;
+
+#if __EMBY__
+    [DisplayName("OpenAI model")]
+    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAiX)]
+#endif
+    public string OpenAiXModel { get; set; } = "gpt-3.5-turbo";
 }

--- a/Jellyfin.Plugin.MetaTube/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.MetaTube/Configuration/PluginConfiguration.cs
@@ -205,6 +205,12 @@ public class PluginConfiguration : BasePluginConfiguration
     public string OpenAiXModel { get; set; } = "gpt-3.5-turbo";
 
 #if __EMBY__
+    [DisplayName("OpenAI system prompt")]
+    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAiX)]
+#endif
+    public string OpenAiXSystemPrompt { get; set; } = string.Empty;
+
+#if __EMBY__
     [DisplayName("Enable title substitution")]
 #endif
     public bool EnableTitleSubstitution { get; set; } = false;

--- a/Jellyfin.Plugin.MetaTube/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.MetaTube/Configuration/PluginConfiguration.cs
@@ -175,6 +175,36 @@ public class PluginConfiguration : BasePluginConfiguration
     public string OpenAiApiKey { get; set; } = string.Empty;
 
 #if __EMBY__
+    [DisplayName("DeepLX api key")]
+    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.DeepLX)]
+#endif
+    public string DeepLXApiKey { get; set; } = string.Empty;
+
+#if __EMBY__
+    [DisplayName("DeepLX base url")]
+    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.DeepLX)]
+#endif
+    public string DeepLXBaseUrl { get; set; } = string.Empty;
+
+#if __EMBY__
+    [DisplayName("OpenAI api key")]
+    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAiX)]
+#endif
+    public string OpenAiXApiKey { get; set; } = string.Empty;
+
+#if __EMBY__
+    [DisplayName("OpenAI base url")]
+    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAiX)]
+#endif
+    public string OpenAiXBaseUrl { get; set; } = string.Empty;
+
+#if __EMBY__
+    [DisplayName("OpenAI model")]
+    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAiX)]
+#endif
+    public string OpenAiXModel { get; set; } = "gpt-3.5-turbo";
+
+#if __EMBY__
     [DisplayName("Enable title substitution")]
 #endif
     public bool EnableTitleSubstitution { get; set; } = false;
@@ -245,34 +275,4 @@ public class PluginConfiguration : BasePluginConfiguration
     }
 
     private SubstitutionTable _genreSubstitutionTable;
-
-#if __EMBY__
-    [DisplayName("DeepLX api key")]
-    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.DeepLX)]
-#endif
-    public string DeepLXApiKey { get; set; } = string.Empty;
-
-#if __EMBY__
-    [DisplayName("DeepLX base url")]
-    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.DeepLX)]
-#endif
-    public string DeepLXBaseUrl { get; set; } = string.Empty;
-
-#if __EMBY__
-    [DisplayName("OpenAI api key")]
-    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAiX)]
-#endif
-    public string OpenAiXApiKey { get; set; } = string.Empty;
-
-#if __EMBY__
-    [DisplayName("OpenAI base url")]
-    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAiX)]
-#endif
-    public string OpenAiXBaseUrl { get; set; } = string.Empty;
-
-#if __EMBY__
-    [DisplayName("OpenAI model")]
-    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAiX)]
-#endif
-    public string OpenAiXModel { get; set; } = "gpt-3.5-turbo";
 }

--- a/Jellyfin.Plugin.MetaTube/Configuration/configPage.html
+++ b/Jellyfin.Plugin.MetaTube/Configuration/configPage.html
@@ -245,6 +245,10 @@
                                 <input id="txtOpenAiXModel" is="emby-input" name="txtOpenAiXModel" type="text" />
                                 <div class="fieldDescription">Custom model for OpenAI API (default: gpt-3.5-turbo)</div>
                             </div>
+                            <div class="inputContainer">
+                                <textarea class="emby-input" id="txtOpenAiXSystemPrompt" label="OpenAI system prompt" rows="6"></textarea>
+                                <div class="fieldDescription">Custom system prompt for translation. Leave empty to use default prompt.</div>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -401,6 +405,7 @@
                 $('#txtOpenAiXBaseUrl', page).val(config.OpenAiXBaseUrl).change();
                 $('#txtOpenAiXApiKey', page).val(config.OpenAiXApiKey).change();
                 $('#txtOpenAiXModel', page).val(config.OpenAiXModel).change();
+                $('#txtOpenAiXSystemPrompt', page).val(config.OpenAiXSystemPrompt).change();
                 page.querySelector('#chkEnableTitleSubstitution').checked = config.EnableTitleSubstitution;
                 $('#txtTitleRawSubstitutionTable', page).val(config.TitleRawSubstitutionTable).change();
                 page.querySelector('#chkEnableActorSubstitution').checked = config.EnableActorSubstitution;
@@ -443,6 +448,7 @@
                 config.OpenAiXBaseUrl = $('#txtOpenAiXBaseUrl', form).val();
                 config.OpenAiXApiKey = $('#txtOpenAiXApiKey', form).val();
                 config.OpenAiXModel = $('#txtOpenAiXModel', form).val();
+                config.OpenAiXSystemPrompt = $('#txtOpenAiXSystemPrompt', form).val();
                 config.EnableTitleSubstitution = $('#chkEnableTitleSubstitution', form).prop('checked');
                 config.TitleRawSubstitutionTable = $('#txtTitleRawSubstitutionTable', form).val();
                 config.EnableActorSubstitution = $('#chkEnableActorSubstitution', form).prop('checked');

--- a/Jellyfin.Plugin.MetaTube/Configuration/configPage.html
+++ b/Jellyfin.Plugin.MetaTube/Configuration/configPage.html
@@ -172,7 +172,9 @@
                                 <option value="Google">Google</option>
                                 <option value="GoogleFree">Google (Free)</option>
                                 <option value="DeepL">DeepL (Free)</option>
+                                <option value="DeepLX">DeepLX (Custom)</option>
                                 <option value="OpenAi">OpenAI</option>
+                                <option value="OpenAiX">OpenAI (Custom)</option>
                             </select>
                         </div>
 
@@ -206,6 +208,19 @@
                             </div>
                         </div>
 
+                        <div class="selectTranslationEngineDeepLX">
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="txtDeepLXBaseUrl">DeepL base url:</label>
+                                <input id="txtDeepLXBaseUrl" is="emby-input" name="txtDeepLXBaseUrl" type="text" required />
+                                <div class="fieldDescription">Custom base url for DeepL API (required)</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="txtDeepLXApiKey">DeepL api key:</label>
+                                <input id="txtDeepLXApiKey" is="emby-input" name="txtDeepLXApiKey" type="text" />
+                                <div class="fieldDescription"></div>
+                            </div>
+                        </div>
+
                         <div class="selectTranslationEngineOpenAi">
                             <div class="inputContainer">
                                 <label class="inputLabel inputLabelUnfocused" for="txtOpenAiApiKey">OpenAI api key:</label>
@@ -213,29 +228,17 @@
                                 <div class="fieldDescription"></div>
                             </div>
                         </div>
-                        <div class="selectTranslationEngineDeepLX">
-                            <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="txtDeepLXApiKey">DeepL api key:</label>
-                                <input id="txtDeepLXApiKey" is="emby-input" name="txtDeepLXApiKey" type="text" />
-                                <div class="fieldDescription"></div>
-                            </div>
-                            <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="txtDeepLXBaseUrl">DeepL base url:</label>
-                                <input id="txtDeepLXBaseUrl" is="emby-input" name="txtDeepLXBaseUrl" type="text" required />
-                                <div class="fieldDescription">Custom base url for DeepL API (required)</div>
-                            </div>
-                        </div>
-                        
+
                         <div class="selectTranslationEngineOpenAiX">
-                            <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="txtOpenAiXApiKey">OpenAI api key:</label>
-                                <input id="txtOpenAiXApiKey" is="emby-input" name="txtOpenAiXApiKey" type="text" />
-                                <div class="fieldDescription"></div>
-                            </div>
                             <div class="inputContainer">
                                 <label class="inputLabel inputLabelUnfocused" for="txtOpenAiXBaseUrl">OpenAI base url:</label>
                                 <input id="txtOpenAiXBaseUrl" is="emby-input" name="txtOpenAiXBaseUrl" type="text" required />
                                 <div class="fieldDescription">Custom base url for OpenAI API or compatible API (required)</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="txtOpenAiXApiKey">OpenAI api key:</label>
+                                <input id="txtOpenAiXApiKey" is="emby-input" name="txtOpenAiXApiKey" type="text" />
+                                <div class="fieldDescription"></div>
                             </div>
                             <div class="inputContainer">
                                 <label class="inputLabel inputLabelUnfocused" for="txtOpenAiXModel">OpenAI model:</label>
@@ -318,33 +321,43 @@
                 $('.selectTranslationEngineBaidu').css('display', 'inherit');
                 $('.selectTranslationEngineGoogle').css('display', 'none');
                 $('.selectTranslationEngineDeepL').css('display', 'none');
+                $('.selectTranslationEngineDeepLX').css('display', 'none');
                 $('.selectTranslationEngineOpenAi').css('display', 'none');
+                $('.selectTranslationEngineOpenAiX').css('display', 'none');
             } else if (this.value === "Google") {
                 $('.selectTranslationEngineBaidu').css('display', 'none');
                 $('.selectTranslationEngineGoogle').css('display', 'inherit');
                 $('.selectTranslationEngineDeepL').css('display', 'none');
+                $('.selectTranslationEngineDeepLX').css('display', 'none');
                 $('.selectTranslationEngineOpenAi').css('display', 'none');
+                $('.selectTranslationEngineOpenAiX').css('display', 'none');
             } else if (this.value === "GoogleFree") {
                 $('.selectTranslationEngineBaidu').css('display', 'none');
                 $('.selectTranslationEngineGoogle').css('display', 'none');
                 $('.selectTranslationEngineDeepL').css('display', 'none');
+                $('.selectTranslationEngineDeepLX').css('display', 'none');
                 $('.selectTranslationEngineOpenAi').css('display', 'none');
+                $('.selectTranslationEngineOpenAiX').css('display', 'none');
             } else if (this.value === "DeepL") {
                 $('.selectTranslationEngineBaidu').css('display', 'none');
                 $('.selectTranslationEngineGoogle').css('display', 'none');
                 $('.selectTranslationEngineDeepL').css('display', 'inherit');
+                $('.selectTranslationEngineDeepLX').css('display', 'none');
                 $('.selectTranslationEngineOpenAi').css('display', 'none');
-            } else if (this.value === "OpenAi") {
-                $('.selectTranslationEngineBaidu').css('display', 'none');
-                $('.selectTranslationEngineGoogle').css('display', 'none');
-                $('.selectTranslationEngineDeepL').css('display', 'none');
-                $('.selectTranslationEngineOpenAi').css('display', 'inherit');
+                $('.selectTranslationEngineOpenAiX').css('display', 'none');
             } else if (this.value === "DeepLX") {
                 $('.selectTranslationEngineBaidu').css('display', 'none');
                 $('.selectTranslationEngineGoogle').css('display', 'none');
                 $('.selectTranslationEngineDeepL').css('display', 'none');
                 $('.selectTranslationEngineDeepLX').css('display', 'inherit');
                 $('.selectTranslationEngineOpenAi').css('display', 'none');
+                $('.selectTranslationEngineOpenAiX').css('display', 'none');
+            } else if (this.value === "OpenAi") {
+                $('.selectTranslationEngineBaidu').css('display', 'none');
+                $('.selectTranslationEngineGoogle').css('display', 'none');
+                $('.selectTranslationEngineDeepL').css('display', 'none');
+                $('.selectTranslationEngineDeepLX').css('display', 'none');
+                $('.selectTranslationEngineOpenAi').css('display', 'inherit');
                 $('.selectTranslationEngineOpenAiX').css('display', 'none');
             } else if (this.value === "OpenAiX") {
                 $('.selectTranslationEngineBaidu').css('display', 'none');
@@ -383,10 +396,10 @@
                 $('#txtGoogleApiKey', page).val(config.GoogleApiKey).change();
                 $('#txtDeepLApiKey', page).val(config.DeepLApiKey).change();
                 $('#txtOpenAiApiKey', page).val(config.OpenAiApiKey).change();
-                $('#txtDeepLXApiKey', page).val(config.DeepLXApiKey).change();
                 $('#txtDeepLXBaseUrl', page).val(config.DeepLXBaseUrl).change();
-                $('#txtOpenAiXApiKey', page).val(config.OpenAiXApiKey).change();
+                $('#txtDeepLXApiKey', page).val(config.DeepLXApiKey).change();
                 $('#txtOpenAiXBaseUrl', page).val(config.OpenAiXBaseUrl).change();
+                $('#txtOpenAiXApiKey', page).val(config.OpenAiXApiKey).change();
                 $('#txtOpenAiXModel', page).val(config.OpenAiXModel).change();
                 page.querySelector('#chkEnableTitleSubstitution').checked = config.EnableTitleSubstitution;
                 $('#txtTitleRawSubstitutionTable', page).val(config.TitleRawSubstitutionTable).change();
@@ -425,10 +438,10 @@
                 config.GoogleApiKey = $('#txtGoogleApiKey', form).val();
                 config.DeepLApiKey = $('#txtDeepLApiKey', form).val();
                 config.OpenAiApiKey = $('#txtOpenAiApiKey', form).val();
-                config.DeepLXApiKey = $('#txtDeepLXApiKey', form).val();
                 config.DeepLXBaseUrl = $('#txtDeepLXBaseUrl', form).val();
-                config.OpenAiXApiKey = $('#txtOpenAiXApiKey', form).val();
+                config.DeepLXApiKey = $('#txtDeepLXApiKey', form).val();
                 config.OpenAiXBaseUrl = $('#txtOpenAiXBaseUrl', form).val();
+                config.OpenAiXApiKey = $('#txtOpenAiXApiKey', form).val();
                 config.OpenAiXModel = $('#txtOpenAiXModel', form).val();
                 config.EnableTitleSubstitution = $('#chkEnableTitleSubstitution', form).prop('checked');
                 config.TitleRawSubstitutionTable = $('#txtTitleRawSubstitutionTable', form).val();

--- a/Jellyfin.Plugin.MetaTube/Configuration/configPage.html
+++ b/Jellyfin.Plugin.MetaTube/Configuration/configPage.html
@@ -213,6 +213,36 @@
                                 <div class="fieldDescription"></div>
                             </div>
                         </div>
+                        <div class="selectTranslationEngineDeepLX">
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="txtDeepLXApiKey">DeepL api key:</label>
+                                <input id="txtDeepLXApiKey" is="emby-input" name="txtDeepLXApiKey" type="text" />
+                                <div class="fieldDescription"></div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="txtDeepLXBaseUrl">DeepL base url:</label>
+                                <input id="txtDeepLXBaseUrl" is="emby-input" name="txtDeepLXBaseUrl" type="text" required />
+                                <div class="fieldDescription">Custom base url for DeepL API (required)</div>
+                            </div>
+                        </div>
+                        
+                        <div class="selectTranslationEngineOpenAiX">
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="txtOpenAiXApiKey">OpenAI api key:</label>
+                                <input id="txtOpenAiXApiKey" is="emby-input" name="txtOpenAiXApiKey" type="text" />
+                                <div class="fieldDescription"></div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="txtOpenAiXBaseUrl">OpenAI base url:</label>
+                                <input id="txtOpenAiXBaseUrl" is="emby-input" name="txtOpenAiXBaseUrl" type="text" required />
+                                <div class="fieldDescription">Custom base url for OpenAI API or compatible API (required)</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="txtOpenAiXModel">OpenAI model:</label>
+                                <input id="txtOpenAiXModel" is="emby-input" name="txtOpenAiXModel" type="text" />
+                                <div class="fieldDescription">Custom model for OpenAI API (default: gpt-3.5-turbo)</div>
+                            </div>
+                        </div>
                     </div>
                 </div>
 
@@ -309,11 +339,20 @@
                 $('.selectTranslationEngineGoogle').css('display', 'none');
                 $('.selectTranslationEngineDeepL').css('display', 'none');
                 $('.selectTranslationEngineOpenAi').css('display', 'inherit');
-            } else {
+            } else if (this.value === "DeepLX") {
                 $('.selectTranslationEngineBaidu').css('display', 'none');
                 $('.selectTranslationEngineGoogle').css('display', 'none');
                 $('.selectTranslationEngineDeepL').css('display', 'none');
+                $('.selectTranslationEngineDeepLX').css('display', 'inherit');
                 $('.selectTranslationEngineOpenAi').css('display', 'none');
+                $('.selectTranslationEngineOpenAiX').css('display', 'none');
+            } else if (this.value === "OpenAiX") {
+                $('.selectTranslationEngineBaidu').css('display', 'none');
+                $('.selectTranslationEngineGoogle').css('display', 'none');
+                $('.selectTranslationEngineDeepL').css('display', 'none');
+                $('.selectTranslationEngineDeepLX').css('display', 'none');
+                $('.selectTranslationEngineOpenAi').css('display', 'none');
+                $('.selectTranslationEngineOpenAiX').css('display', 'inherit');
             }
         });
 
@@ -344,6 +383,11 @@
                 $('#txtGoogleApiKey', page).val(config.GoogleApiKey).change();
                 $('#txtDeepLApiKey', page).val(config.DeepLApiKey).change();
                 $('#txtOpenAiApiKey', page).val(config.OpenAiApiKey).change();
+                $('#txtDeepLXApiKey', page).val(config.DeepLXApiKey).change();
+                $('#txtDeepLXBaseUrl', page).val(config.DeepLXBaseUrl).change();
+                $('#txtOpenAiXApiKey', page).val(config.OpenAiXApiKey).change();
+                $('#txtOpenAiXBaseUrl', page).val(config.OpenAiXBaseUrl).change();
+                $('#txtOpenAiXModel', page).val(config.OpenAiXModel).change();
                 page.querySelector('#chkEnableTitleSubstitution').checked = config.EnableTitleSubstitution;
                 $('#txtTitleRawSubstitutionTable', page).val(config.TitleRawSubstitutionTable).change();
                 page.querySelector('#chkEnableActorSubstitution').checked = config.EnableActorSubstitution;
@@ -381,6 +425,11 @@
                 config.GoogleApiKey = $('#txtGoogleApiKey', form).val();
                 config.DeepLApiKey = $('#txtDeepLApiKey', form).val();
                 config.OpenAiApiKey = $('#txtOpenAiApiKey', form).val();
+                config.DeepLXApiKey = $('#txtDeepLXApiKey', form).val();
+                config.DeepLXBaseUrl = $('#txtDeepLXBaseUrl', form).val();
+                config.OpenAiXApiKey = $('#txtOpenAiXApiKey', form).val();
+                config.OpenAiXBaseUrl = $('#txtOpenAiXBaseUrl', form).val();
+                config.OpenAiXModel = $('#txtOpenAiXModel', form).val();
                 config.EnableTitleSubstitution = $('#chkEnableTitleSubstitution', form).prop('checked');
                 config.TitleRawSubstitutionTable = $('#txtTitleRawSubstitutionTable', form).val();
                 config.EnableActorSubstitution = $('#chkEnableActorSubstitution', form).prop('checked');

--- a/Jellyfin.Plugin.MetaTube/Translation/TranslationEngine.cs
+++ b/Jellyfin.Plugin.MetaTube/Translation/TranslationEngine.cs
@@ -16,7 +16,7 @@ public enum TranslationEngine
     [Description("DeepL (Free)")]
     DeepL,
 
-    [Description("DeepL (Custom)")]
+    [Description("DeepLX (Custom)")]
     DeepLX,
 
     [Description("OpenAI")]

--- a/Jellyfin.Plugin.MetaTube/Translation/TranslationEngine.cs
+++ b/Jellyfin.Plugin.MetaTube/Translation/TranslationEngine.cs
@@ -16,6 +16,12 @@ public enum TranslationEngine
     [Description("DeepL (Free)")]
     DeepL,
 
+    [Description("DeepL (Custom)")]
+    DeepLX,
+
     [Description("OpenAI")]
-    OpenAi
+    OpenAi,
+
+    [Description("OpenAI (Custom)")]
+    OpenAiX
 }

--- a/Jellyfin.Plugin.MetaTube/Translation/TranslationHelper.cs
+++ b/Jellyfin.Plugin.MetaTube/Translation/TranslationHelper.cs
@@ -46,11 +46,28 @@ public static class TranslationHelper
                     { "deepl-api-key", Configuration.DeepLApiKey }
                 });
                 break;
+            case TranslationEngine.DeepLX:
+                millisecondsDelay = 100;
+                nv.Add(new NameValueCollection
+                {
+                    { "deepl-api-key", Configuration.DeepLXApiKey },
+                    { "base-url", Configuration.DeepLXBaseUrl }
+                });
+                break;
             case TranslationEngine.OpenAi:
                 millisecondsDelay = 1000;
                 nv.Add(new NameValueCollection
                 {
                     { "openai-api-key", Configuration.OpenAiApiKey }
+                });
+                break;
+            case TranslationEngine.OpenAiX:
+                millisecondsDelay = 1000;
+                nv.Add(new NameValueCollection
+                {
+                    { "openai-api-key", Configuration.OpenAiXApiKey },
+                    { "base-url", Configuration.OpenAiXBaseUrl },
+                    { "model", Configuration.OpenAiXModel }
                 });
                 break;
             default:

--- a/Jellyfin.Plugin.MetaTube/Translation/TranslationHelper.cs
+++ b/Jellyfin.Plugin.MetaTube/Translation/TranslationHelper.cs
@@ -67,7 +67,8 @@ public static class TranslationHelper
                 {
                     { "openai-api-key", Configuration.OpenAiXApiKey },
                     { "base-url", Configuration.OpenAiXBaseUrl },
-                    { "model", Configuration.OpenAiXModel }
+                    { "model", Configuration.OpenAiXModel },
+                    { "system-prompt", Configuration.OpenAiXSystemPrompt }
                 });
                 break;
             default:


### PR DESCRIPTION
增加了自定义翻译配置
新增了 deeplx 翻译引擎，可自定义 baseUrl、apiKey
新增了 openAiX 翻译引擎, 可自定义 baseUrl、apiKey、model

openAiX 可以使用与openAi兼容的服务，如 deepseek

方便使用代理站服务

![image](https://github.com/user-attachments/assets/dfdf24e1-6642-4168-b3bc-da313add027b)
![image](https://github.com/user-attachments/assets/a540b0a7-e571-4029-9eaa-09c3dbf61f1c)
