### PR TITLE
Feature: add `openai` custom translation support

### DIFF
--- a/Jellyfin.Plugin.MetaTube/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.MetaTube/Configuration/PluginConfiguration.cs
@@ -181,6 +181,30 @@ public class PluginConfiguration : BasePluginConfiguration
     public string OpenAiApiKey { get; set; } = string.Empty;
 
 #if __EMBY__
+    [DisplayName("OpenAI base url")]
+    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAiX)]
+#endif
+    public string OpenAiXBaseUrl { get; set; } = string.Empty;
+
+#if __EMBY__
+    [DisplayName("OpenAI api key")]
+    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAiX)]
+#endif
+    public string OpenAiXApiKey { get; set; } = string.Empty;
+
+#if __EMBY__
+    [DisplayName("OpenAI model")]
+    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAiX)]
+#endif
+    public string OpenAiXModel { get; set; } = "gpt-3.5-turbo";
+
+#if __EMBY__
+    [DisplayName("OpenAI system prompt")]
+    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAiX)]
+#endif
+    public string OpenAiXSystemPrompt { get; set; } = string.Empty;
+
+#if __EMBY__
     [DisplayName("Enable title substitution")]
 #endif
     public bool EnableTitleSubstitution { get; set; } = false;

--- a/Jellyfin.Plugin.MetaTube/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.MetaTube/Configuration/PluginConfiguration.cs
@@ -181,28 +181,18 @@ public class PluginConfiguration : BasePluginConfiguration
     public string OpenAiApiKey { get; set; } = string.Empty;
 
 #if __EMBY__
-    [DisplayName("OpenAI base url")]
-    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAiX)]
+    [DisplayName("OpenAI api url")]
+    [Description("Custom OpenAI-compatible api endpoint url. (optional)")]
+    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAi)]
 #endif
-    public string OpenAiXBaseUrl { get; set; } = string.Empty;
-
-#if __EMBY__
-    [DisplayName("OpenAI api key")]
-    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAiX)]
-#endif
-    public string OpenAiXApiKey { get; set; } = string.Empty;
+    public string OpenAiApiUrl { get; set; } = string.Empty;
 
 #if __EMBY__
     [DisplayName("OpenAI model")]
-    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAiX)]
+    [Description("Custom OpenAI-compatible api model. (optional)")]
+    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAi)]
 #endif
-    public string OpenAiXModel { get; set; } = "gpt-3.5-turbo";
-
-#if __EMBY__
-    [DisplayName("OpenAI system prompt")]
-    [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAiX)]
-#endif
-    public string OpenAiXSystemPrompt { get; set; } = string.Empty;
+    public string OpenAiModel { get; set; } = string.Empty;
 
 #if __EMBY__
     [DisplayName("Enable title substitution")]

--- a/Jellyfin.Plugin.MetaTube/Configuration/PluginConfiguration.cs
+++ b/Jellyfin.Plugin.MetaTube/Configuration/PluginConfiguration.cs
@@ -182,7 +182,7 @@ public class PluginConfiguration : BasePluginConfiguration
 
 #if __EMBY__
     [DisplayName("OpenAI api url")]
-    [Description("Custom OpenAI-compatible api endpoint url. (optional)")]
+    [Description("Custom OpenAI-compatible api url. (optional)")]
     [VisibleCondition(nameof(TranslationEngine), ValueCondition.IsEqual, TranslationEngine.OpenAi)]
 #endif
     public string OpenAiApiUrl { get; set; } = string.Empty;

--- a/Jellyfin.Plugin.MetaTube/Configuration/configPage.html
+++ b/Jellyfin.Plugin.MetaTube/Configuration/configPage.html
@@ -304,44 +304,31 @@
                 $('.selectTranslationEngineGoogle').css('display', 'none');
                 $('.selectTranslationEngineDeepL').css('display', 'none');
                 $('.selectTranslationEngineOpenAi').css('display', 'none');
-                $('.selectTranslationEngineOpenAiX').css('display', 'none');
             } else if (this.value === "Google") {
                 $('.selectTranslationEngineBaidu').css('display', 'none');
                 $('.selectTranslationEngineGoogle').css('display', 'inherit');
                 $('.selectTranslationEngineDeepL').css('display', 'none');
                 $('.selectTranslationEngineOpenAi').css('display', 'none');
-                $('.selectTranslationEngineOpenAiX').css('display', 'none');
             } else if (this.value === "GoogleFree") {
                 $('.selectTranslationEngineBaidu').css('display', 'none');
                 $('.selectTranslationEngineGoogle').css('display', 'none');
                 $('.selectTranslationEngineDeepL').css('display', 'none');
                 $('.selectTranslationEngineOpenAi').css('display', 'none');
-                $('.selectTranslationEngineOpenAiX').css('display', 'none');
             } else if (this.value === "DeepL") {
                 $('.selectTranslationEngineBaidu').css('display', 'none');
                 $('.selectTranslationEngineGoogle').css('display', 'none');
                 $('.selectTranslationEngineDeepL').css('display', 'inherit');
                 $('.selectTranslationEngineOpenAi').css('display', 'none');
-                $('.selectTranslationEngineOpenAiX').css('display', 'none');
             } else if (this.value === "OpenAi") {
                 $('.selectTranslationEngineBaidu').css('display', 'none');
                 $('.selectTranslationEngineGoogle').css('display', 'none');
                 $('.selectTranslationEngineDeepL').css('display', 'none');
                 $('.selectTranslationEngineOpenAi').css('display', 'inherit');
-                $('.selectTranslationEngineOpenAiX').css('display', 'none');
-            } else if (this.value === "OpenAiX") {
-                $('.selectTranslationEngineBaidu').css('display', 'none');
-                $('.selectTranslationEngineGoogle').css('display', 'none');
-                $('.selectTranslationEngineDeepL').css('display', 'none');
-                $('.selectTranslationEngineDeepLX').css('display', 'none');
-                $('.selectTranslationEngineOpenAi').css('display', 'none');
-                $('.selectTranslationEngineOpenAiX').css('display', 'inherit');
             } else {
                 $('.selectTranslationEngineBaidu').css('display', 'none');
                 $('.selectTranslationEngineGoogle').css('display', 'none');
                 $('.selectTranslationEngineDeepL').css('display', 'none');
                 $('.selectTranslationEngineOpenAi').css('display', 'none');
-                $('.selectTranslationEngineOpenAiX').css('display', 'none');
             }
         });
 

--- a/Jellyfin.Plugin.MetaTube/Configuration/configPage.html
+++ b/Jellyfin.Plugin.MetaTube/Configuration/configPage.html
@@ -218,6 +218,28 @@
                                 <div class="fieldDescription"></div>
                             </div>
                         </div>
+
+                        <div class="selectTranslationEngineOpenAiX">
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="txtOpenAiXBaseUrl">OpenAI base url:</label>
+                                <input id="txtOpenAiXBaseUrl" is="emby-input" name="txtOpenAiXBaseUrl" type="text" required />
+                                <div class="fieldDescription">Custom base url for OpenAI API or compatible API (required)</div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="txtOpenAiXApiKey">OpenAI api key:</label>
+                                <input id="txtOpenAiXApiKey" is="emby-input" name="txtOpenAiXApiKey" type="text" />
+                                <div class="fieldDescription"></div>
+                            </div>
+                            <div class="inputContainer">
+                                <label class="inputLabel inputLabelUnfocused" for="txtOpenAiXModel">OpenAI model:</label>
+                                <input id="txtOpenAiXModel" is="emby-input" name="txtOpenAiXModel" type="text" />
+                                <div class="fieldDescription">Custom model for OpenAI API (default: gpt-3.5-turbo)</div>
+                            </div>
+                            <div class="inputContainer">
+                                <textarea class="emby-input" id="txtOpenAiXSystemPrompt" label="OpenAI system prompt" rows="6"></textarea>
+                                <div class="fieldDescription">Custom system prompt for translation. Leave empty to use default prompt.</div>
+                            </div>
+                        </div>
                     </div>
                 </div>
 
@@ -294,31 +316,44 @@
                 $('.selectTranslationEngineGoogle').css('display', 'none');
                 $('.selectTranslationEngineDeepL').css('display', 'none');
                 $('.selectTranslationEngineOpenAi').css('display', 'none');
+                $('.selectTranslationEngineOpenAiX').css('display', 'none');
             } else if (this.value === "Google") {
                 $('.selectTranslationEngineBaidu').css('display', 'none');
                 $('.selectTranslationEngineGoogle').css('display', 'inherit');
                 $('.selectTranslationEngineDeepL').css('display', 'none');
                 $('.selectTranslationEngineOpenAi').css('display', 'none');
+                $('.selectTranslationEngineOpenAiX').css('display', 'none');
             } else if (this.value === "GoogleFree") {
                 $('.selectTranslationEngineBaidu').css('display', 'none');
                 $('.selectTranslationEngineGoogle').css('display', 'none');
                 $('.selectTranslationEngineDeepL').css('display', 'none');
                 $('.selectTranslationEngineOpenAi').css('display', 'none');
+                $('.selectTranslationEngineOpenAiX').css('display', 'none');
             } else if (this.value === "DeepL") {
                 $('.selectTranslationEngineBaidu').css('display', 'none');
                 $('.selectTranslationEngineGoogle').css('display', 'none');
                 $('.selectTranslationEngineDeepL').css('display', 'inherit');
                 $('.selectTranslationEngineOpenAi').css('display', 'none');
+                $('.selectTranslationEngineOpenAiX').css('display', 'none');
             } else if (this.value === "OpenAi") {
                 $('.selectTranslationEngineBaidu').css('display', 'none');
                 $('.selectTranslationEngineGoogle').css('display', 'none');
                 $('.selectTranslationEngineDeepL').css('display', 'none');
                 $('.selectTranslationEngineOpenAi').css('display', 'inherit');
+                $('.selectTranslationEngineOpenAiX').css('display', 'none');
+            } else if (this.value === "OpenAiX") {
+                $('.selectTranslationEngineBaidu').css('display', 'none');
+                $('.selectTranslationEngineGoogle').css('display', 'none');
+                $('.selectTranslationEngineDeepL').css('display', 'none');
+                $('.selectTranslationEngineDeepLX').css('display', 'none');
+                $('.selectTranslationEngineOpenAi').css('display', 'none');
+                $('.selectTranslationEngineOpenAiX').css('display', 'inherit');
             } else {
                 $('.selectTranslationEngineBaidu').css('display', 'none');
                 $('.selectTranslationEngineGoogle').css('display', 'none');
                 $('.selectTranslationEngineDeepL').css('display', 'none');
                 $('.selectTranslationEngineOpenAi').css('display', 'none');
+                $('.selectTranslationEngineOpenAiX').css('display', 'none');
             }
         });
 
@@ -350,6 +385,10 @@
                 $('#txtDeepLApiKey', page).val(config.DeepLApiKey).change();
                 $('#txtDeepLAltUrl', page).val(config.DeepLAltUrl).change();
                 $('#txtOpenAiApiKey', page).val(config.OpenAiApiKey).change();
+                $('#txtOpenAiXBaseUrl', page).val(config.OpenAiXBaseUrl).change();
+                $('#txtOpenAiXApiKey', page).val(config.OpenAiXApiKey).change();
+                $('#txtOpenAiXModel', page).val(config.OpenAiXModel).change();
+                $('#txtOpenAiXSystemPrompt', page).val(config.OpenAiXSystemPrompt).change();
                 page.querySelector('#chkEnableTitleSubstitution').checked = config.EnableTitleSubstitution;
                 $('#txtTitleRawSubstitutionTable', page).val(config.TitleRawSubstitutionTable).change();
                 page.querySelector('#chkEnableActorSubstitution').checked = config.EnableActorSubstitution;
@@ -388,6 +427,10 @@
                 config.DeepLApiKey = $('#txtDeepLApiKey', form).val();
                 config.DeepLXAltUrl = $('#txtDeepLAltUrl', form).val();
                 config.OpenAiApiKey = $('#txtOpenAiApiKey', form).val();
+                config.OpenAiXBaseUrl = $('#txtOpenAiXBaseUrl', form).val();
+                config.OpenAiXApiKey = $('#txtOpenAiXApiKey', form).val();
+                config.OpenAiXModel = $('#txtOpenAiXModel', form).val();
+                config.OpenAiXSystemPrompt = $('#txtOpenAiXSystemPrompt', form).val();
                 config.EnableTitleSubstitution = $('#chkEnableTitleSubstitution', form).prop('checked');
                 config.TitleRawSubstitutionTable = $('#txtTitleRawSubstitutionTable', form).val();
                 config.EnableActorSubstitution = $('#chkEnableActorSubstitution', form).prop('checked');

--- a/Jellyfin.Plugin.MetaTube/Configuration/configPage.html
+++ b/Jellyfin.Plugin.MetaTube/Configuration/configPage.html
@@ -217,27 +217,15 @@
                                 <input id="txtOpenAiApiKey" is="emby-input" name="txtOpenAiApiKey" type="text"/>
                                 <div class="fieldDescription"></div>
                             </div>
-                        </div>
-
-                        <div class="selectTranslationEngineOpenAiX">
                             <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="txtOpenAiXBaseUrl">OpenAI base url:</label>
-                                <input id="txtOpenAiXBaseUrl" is="emby-input" name="txtOpenAiXBaseUrl" type="text" required />
-                                <div class="fieldDescription">Custom base url for OpenAI API or compatible API (required)</div>
+                                <label class="inputLabel inputLabelUnfocused" for="txtOpenAiApiUrl">OpenAI api url:</label>
+                                <input id="txtOpenAiApiUrl" is="emby-input" name="txtOpenAiApiUrl" required type="text"/>
+                                <div class="fieldDescription">Custom OpenAI-compatible api endpoint url. (optional)</div>
                             </div>
                             <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="txtOpenAiXApiKey">OpenAI api key:</label>
-                                <input id="txtOpenAiXApiKey" is="emby-input" name="txtOpenAiXApiKey" type="text" />
-                                <div class="fieldDescription"></div>
-                            </div>
-                            <div class="inputContainer">
-                                <label class="inputLabel inputLabelUnfocused" for="txtOpenAiXModel">OpenAI model:</label>
-                                <input id="txtOpenAiXModel" is="emby-input" name="txtOpenAiXModel" type="text" />
-                                <div class="fieldDescription">Custom model for OpenAI API (default: gpt-3.5-turbo)</div>
-                            </div>
-                            <div class="inputContainer">
-                                <textarea class="emby-input" id="txtOpenAiXSystemPrompt" label="OpenAI system prompt" rows="6"></textarea>
-                                <div class="fieldDescription">Custom system prompt for translation. Leave empty to use default prompt.</div>
+                                <label class="inputLabel inputLabelUnfocused" for="txtOpenAiModel">OpenAI model:</label>
+                                <input id="txtOpenAiModel" is="emby-input" name="txtOpenAiModel" type="text"/>
+                                <div class="fieldDescription">Custom OpenAI-compatible api model. (optional)</div>
                             </div>
                         </div>
                     </div>
@@ -385,10 +373,8 @@
                 $('#txtDeepLApiKey', page).val(config.DeepLApiKey).change();
                 $('#txtDeepLAltUrl', page).val(config.DeepLAltUrl).change();
                 $('#txtOpenAiApiKey', page).val(config.OpenAiApiKey).change();
-                $('#txtOpenAiXBaseUrl', page).val(config.OpenAiXBaseUrl).change();
-                $('#txtOpenAiXApiKey', page).val(config.OpenAiXApiKey).change();
-                $('#txtOpenAiXModel', page).val(config.OpenAiXModel).change();
-                $('#txtOpenAiXSystemPrompt', page).val(config.OpenAiXSystemPrompt).change();
+                $('#txtOpenAiApiUrl', page).val(config.OpenAiApiUrl).change();
+                $('#txtOpenAiModel', page).val(config.OpenAiModel).change();
                 page.querySelector('#chkEnableTitleSubstitution').checked = config.EnableTitleSubstitution;
                 $('#txtTitleRawSubstitutionTable', page).val(config.TitleRawSubstitutionTable).change();
                 page.querySelector('#chkEnableActorSubstitution').checked = config.EnableActorSubstitution;
@@ -427,10 +413,8 @@
                 config.DeepLApiKey = $('#txtDeepLApiKey', form).val();
                 config.DeepLXAltUrl = $('#txtDeepLAltUrl', form).val();
                 config.OpenAiApiKey = $('#txtOpenAiApiKey', form).val();
-                config.OpenAiXBaseUrl = $('#txtOpenAiXBaseUrl', form).val();
-                config.OpenAiXApiKey = $('#txtOpenAiXApiKey', form).val();
-                config.OpenAiXModel = $('#txtOpenAiXModel', form).val();
-                config.OpenAiXSystemPrompt = $('#txtOpenAiXSystemPrompt', form).val();
+                config.OpenAiApiUrl = $('#txtOpenAiApiUrl', form).val();
+                config.OpenAiModel = $('#txtOpenAiModel', form).val();
                 config.EnableTitleSubstitution = $('#chkEnableTitleSubstitution', form).prop('checked');
                 config.TitleRawSubstitutionTable = $('#txtTitleRawSubstitutionTable', form).val();
                 config.EnableActorSubstitution = $('#chkEnableActorSubstitution', form).prop('checked');

--- a/Jellyfin.Plugin.MetaTube/Configuration/configPage.html
+++ b/Jellyfin.Plugin.MetaTube/Configuration/configPage.html
@@ -220,7 +220,7 @@
                             <div class="inputContainer">
                                 <label class="inputLabel inputLabelUnfocused" for="txtOpenAiApiUrl">OpenAI api url:</label>
                                 <input id="txtOpenAiApiUrl" is="emby-input" name="txtOpenAiApiUrl" required type="text"/>
-                                <div class="fieldDescription">Custom OpenAI-compatible api endpoint url. (optional)</div>
+                                <div class="fieldDescription">Custom OpenAI-compatible api url. (optional)</div>
                             </div>
                             <div class="inputContainer">
                                 <label class="inputLabel inputLabelUnfocused" for="txtOpenAiModel">OpenAI model:</label>

--- a/Jellyfin.Plugin.MetaTube/Translation/TranslationEngine.cs
+++ b/Jellyfin.Plugin.MetaTube/Translation/TranslationEngine.cs
@@ -17,5 +17,8 @@ public enum TranslationEngine
     DeepL,
 
     [Description("OpenAI")]
-    OpenAi
+    OpenAi,
+
+    [Description("OpenAI (Custom)")]
+    OpenAiX
 }

--- a/Jellyfin.Plugin.MetaTube/Translation/TranslationEngine.cs
+++ b/Jellyfin.Plugin.MetaTube/Translation/TranslationEngine.cs
@@ -17,8 +17,5 @@ public enum TranslationEngine
     DeepL,
 
     [Description("OpenAI")]
-    OpenAi,
-
-    [Description("OpenAI (Custom)")]
-    OpenAiX
+    OpenAi
 }

--- a/Jellyfin.Plugin.MetaTube/Translation/TranslationHelper.cs
+++ b/Jellyfin.Plugin.MetaTube/Translation/TranslationHelper.cs
@@ -54,6 +54,16 @@ public static class TranslationHelper
                     { "openai-api-key", Configuration.OpenAiApiKey }
                 });
                 break;
+            case TranslationEngine.OpenAiX:
+                millisecondsDelay = 1000;
+                nv.Add(new NameValueCollection
+                {
+                    { "openai-api-key", Configuration.OpenAiXApiKey },
+                    { "base-url", Configuration.OpenAiXBaseUrl },
+                    { "model", Configuration.OpenAiXModel },
+                    { "system-prompt", Configuration.OpenAiXSystemPrompt }
+                });
+                break;
             default:
                 throw new ArgumentException($"Invalid translation engine: {Configuration.TranslationEngine}");
         }

--- a/Jellyfin.Plugin.MetaTube/Translation/TranslationHelper.cs
+++ b/Jellyfin.Plugin.MetaTube/Translation/TranslationHelper.cs
@@ -58,10 +58,10 @@ public static class TranslationHelper
                 millisecondsDelay = 1000;
                 nv.Add(new NameValueCollection
                 {
-                    { "openai-api-key", Configuration.OpenAiXApiKey },
-                    { "base-url", Configuration.OpenAiXBaseUrl },
-                    { "model", Configuration.OpenAiXModel },
-                    { "system-prompt", Configuration.OpenAiXSystemPrompt }
+                    { "openaix-api-key", Configuration.OpenAiXApiKey },
+                    { "openaix-base-url", Configuration.OpenAiXBaseUrl },
+                    { "openaix-model", Configuration.OpenAiXModel },
+                    { "openaix-system-prompt", Configuration.OpenAiXSystemPrompt }
                 });
                 break;
             default:

--- a/Jellyfin.Plugin.MetaTube/Translation/TranslationHelper.cs
+++ b/Jellyfin.Plugin.MetaTube/Translation/TranslationHelper.cs
@@ -51,17 +51,9 @@ public static class TranslationHelper
                 millisecondsDelay = 1000;
                 nv.Add(new NameValueCollection
                 {
-                    { "openai-api-key", Configuration.OpenAiApiKey }
-                });
-                break;
-            case TranslationEngine.OpenAiX:
-                millisecondsDelay = 1000;
-                nv.Add(new NameValueCollection
-                {
-                    { "openaix-api-key", Configuration.OpenAiXApiKey },
-                    { "openaix-base-url", Configuration.OpenAiXBaseUrl },
-                    { "openaix-model", Configuration.OpenAiXModel },
-                    { "openaix-system-prompt", Configuration.OpenAiXSystemPrompt }
+                    { "openai-api-key", Configuration.OpenAiApiKey },
+                    { "openai-api-url", Configuration.OpenAiApiUrl },
+                    { "openai-model", Configuration.OpenAiModel }
                 });
                 break;
             default:


### PR DESCRIPTION
add openai custom translation support, users can use the OpenAI API of a third-party agent, or use an OpenAI-compatible model

![image](https://github.com/user-attachments/assets/c69ad391-9788-49bf-ba53-b9e652659111)
