### PR TITLE
Fix: display provider URLs in Jellyfin

### DIFF
--- a/Jellyfin.Plugin.MetaTube/Providers/ExternalUrlProvider.cs
+++ b/Jellyfin.Plugin.MetaTube/Providers/ExternalUrlProvider.cs
@@ -1,0 +1,29 @@
+#if !__EMBY__
+using Jellyfin.Plugin.MetaTube.ExternalIds;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+
+namespace Jellyfin.Plugin.MetaTube.Providers;
+
+public class ExternalUrlProvider : IExternalUrlProvider
+{
+    public string Name => Plugin.Instance.Name;
+
+    public IEnumerable<string> GetExternalUrls(BaseItem item)
+    {
+        var pid = item.GetProviderId(Name);
+
+        switch (item)
+        {
+            case Movie:
+                yield return string.Format((new MovieExternalId()).UrlFormatString, pid);
+                break;
+            case Person:
+                yield return string.Format((new ActorExternalId()).UrlFormatString, pid);
+                break;
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Ref:

- <https://github.com/jellyfin/jellyfin-plugin-tvdb/blob/8ade444/Jellyfin.Plugin.Tvdb/Providers/TvdbExternalUrlProvider.cs>

Thanks to @Topbcy 