### PR TITLE
Feature: Remove ChineseSubtitle Genre for video

### DIFF
--- a/Jellyfin.Plugin.MetaTube/ScheduledTasks/RemoveChineseSubtitleGenreTask.cs
+++ b/Jellyfin.Plugin.MetaTube/ScheduledTasks/RemoveChineseSubtitleGenreTask.cs
@@ -1,0 +1,115 @@
+﻿using System.Text.RegularExpressions;
+using Jellyfin.Plugin.MetaTube.Extensions;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Tasks;
+#if __EMBY__
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Model.Logging;
+
+#else
+using MediaBrowser.Controller.Sorting;
+using Microsoft.Extensions.Logging;
+using Jellyfin.Data.Enums;
+#endif
+
+namespace Jellyfin.Plugin.MetaTube.ScheduledTasks;
+
+public class RemoveChineseSubtitleGenreTask : IScheduledTask
+{
+    private readonly ILibraryManager _libraryManager;
+    private readonly ILogger _logger;
+
+#if __EMBY__
+    public RemoveChineseSubtitleGenreTask(ILogManager logManager, ILibraryManager libraryManager)
+    {
+        _logger = logManager.CreateLogger<OrganizeMetadataTask>();
+        _libraryManager = libraryManager;
+    }
+#else
+    public RemoveChineseSubtitleGenreTask(ILogger<RemoveChineseSubtitleGenreTask> logger, ILibraryManager libraryManager)
+    {
+        _logger = logger;
+        _libraryManager = libraryManager;
+    }
+#endif
+
+    public string Key => $"{Plugin.Instance.Name}RemoveChineseSubtitleGenre";
+
+    public string Name => "Remove ChineseSubtitle Genre";
+
+    public string Description => $"Remove ChineseSubtitle genre provided by {Plugin.Instance.Name} in library.";
+
+    public string Category => Plugin.Instance.Name;
+
+    public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
+    {
+        return Enumerable.Empty<TaskTriggerInfo>();
+    }
+
+#if __EMBY__
+    public async Task Execute(CancellationToken cancellationToken, IProgress<double> progress)
+#else
+    public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+#endif
+    {
+        await Task.Yield();
+
+        progress?.Report(0);
+
+        var items = _libraryManager.GetItemList(new InternalItemsQuery
+        {
+            MediaTypes = new[] { MediaType.Video },
+#if __EMBY__
+            HasAnyProviderId = new[] { Plugin.Instance.Name },
+            IncludeItemTypes = new[] { nameof(Movie) },
+#else
+            HasAnyProviderId = new Dictionary<string, string> { { Plugin.Instance.Name, string.Empty } },
+            IncludeItemTypes = new[] { BaseItemKind.Movie }
+#endif
+        }).ToList();
+
+        foreach (var (idx, item) in items.WithIndex())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            progress?.Report((double)idx / items.Count * 100);
+
+            var genres = item.Genres?.ToList() ?? new List<string>();
+
+            genres.RemoveAll(s => s.Equals(ChineseSubtitle));
+
+            // Remove duplicates.
+            var orderedGenres =
+                (Plugin.Instance.Configuration.EnableGenreSubstitution
+                    // Substitute genres.
+                    ? Plugin.Instance.Configuration.GetGenreSubstitutionTable().Substitute(genres)
+                    : genres).Distinct().OrderByString(genre => genre).ToList();
+
+            // Skip updating item if equal.
+            if (!orderedGenres.Any() ||
+                (item.Genres?.SequenceEqual(orderedGenres, StringComparer.OrdinalIgnoreCase)).GetValueOrDefault(false))
+                continue;
+
+            item.Genres = orderedGenres.ToArray();
+
+            _logger.Info("Remove ChineseSubtitle Genre for video: {0}", item.Name);
+
+#if __EMBY__
+            _libraryManager.UpdateItem(item, item, ItemUpdateType.MetadataEdit, null);
+#else
+            await _libraryManager
+                .UpdateItemAsync(item, item, ItemUpdateType.MetadataEdit, cancellationToken)
+                .ConfigureAwait(false);
+#endif
+        }
+
+        progress?.Report(100);
+    }
+
+    #region Helper
+
+    private const string ChineseSubtitle = "中文字幕";
+
+    #endregion
+}


### PR DESCRIPTION
This PR adds an optional background task to remove the "ChineseSubtitle" genre from media items. It addresses cases where the tag is incorrectly added during library scans (e.g. when "Add Badge" is unchecked), and provides an automated way to clean it up without manual intervention.