### PR TITLE
Improve .strm scraping: graceful not-found handling and catalog number verification

### DIFF
--- a/Jellyfin.Plugin.MetaTube/Providers/MovieImageProvider.cs
+++ b/Jellyfin.Plugin.MetaTube/Providers/MovieImageProvider.cs
@@ -35,51 +35,65 @@ public class MovieImageProvider : BaseProvider, IRemoteImageProvider, IHasOrder
         if (string.IsNullOrWhiteSpace(pid.Id) || string.IsNullOrWhiteSpace(pid.Provider))
             return Enumerable.Empty<RemoteImageInfo>();
 
-        var m = await ApiClient.GetMovieInfoAsync(pid.Provider, pid.Id, cancellationToken);
+        // The base images only need provider/id, so they keep working even when the
+        // metadata detail request fails (e.g. an upstream source is unreachable).
         var images = new List<RemoteImageInfo>
         {
             new()
             {
                 ProviderName = Name,
                 Type = ImageType.Primary,
-                Url = ApiClient.GetPrimaryImageApiUrl(m.Provider, m.Id, pid.Position ?? -1)
+                Url = ApiClient.GetPrimaryImageApiUrl(pid.Provider, pid.Id, pid.Position ?? -1)
             },
             new()
             {
                 ProviderName = Name,
                 Type = ImageType.Thumb,
-                Url = ApiClient.GetThumbImageApiUrl(m.Provider, m.Id)
+                Url = ApiClient.GetThumbImageApiUrl(pid.Provider, pid.Id)
             },
             new()
             {
                 ProviderName = Name,
                 Type = ImageType.Backdrop,
-                Url = ApiClient.GetBackdropImageApiUrl(m.Provider, m.Id)
+                Url = ApiClient.GetBackdropImageApiUrl(pid.Provider, pid.Id)
             }
         };
 
-        foreach (var imageUrl in m.PreviewImages ?? Enumerable.Empty<string>())
+        try
         {
-            images.Add(new RemoteImageInfo
-            {
-                ProviderName = Name,
-                Type = ImageType.Primary,
-                Url = ApiClient.GetPrimaryImageApiUrl(m.Provider, m.Id, imageUrl, pid.Position ?? -1)
-            });
+            var m = await ApiClient.GetMovieInfoAsync(pid.Provider, pid.Id, cancellationToken);
+            if (m == null) return images;
 
-            images.Add(new RemoteImageInfo
-            {
-                ProviderName = Name,
-                Type = ImageType.Thumb,
-                Url = ApiClient.GetThumbImageApiUrl(m.Provider, m.Id, imageUrl)
-            });
+            // Replace the placeholders with the detail-based ones once available.
+            images[2].Url = ApiClient.GetBackdropImageApiUrl(m.Provider, m.Id);
 
-            images.Add(new RemoteImageInfo
+            foreach (var imageUrl in m.PreviewImages ?? Enumerable.Empty<string>())
             {
-                ProviderName = Name,
-                Type = ImageType.Backdrop,
-                Url = ApiClient.GetBackdropImageApiUrl(m.Provider, m.Id, imageUrl)
-            });
+                images.Add(new RemoteImageInfo
+                {
+                    ProviderName = Name,
+                    Type = ImageType.Primary,
+                    Url = ApiClient.GetPrimaryImageApiUrl(m.Provider, m.Id, imageUrl, pid.Position ?? -1)
+                });
+
+                images.Add(new RemoteImageInfo
+                {
+                    ProviderName = Name,
+                    Type = ImageType.Thumb,
+                    Url = ApiClient.GetThumbImageApiUrl(m.Provider, m.Id, imageUrl)
+                });
+
+                images.Add(new RemoteImageInfo
+                {
+                    ProviderName = Name,
+                    Type = ImageType.Backdrop,
+                    Url = ApiClient.GetBackdropImageApiUrl(m.Provider, m.Id, imageUrl)
+                });
+            }
+        }
+        catch (Exception e)
+        {
+            Logger.Warn("Failed to fetch movie details for extra images: {0} ({1})", pid.Id, e.Message);
         }
 
         return images;

--- a/Jellyfin.Plugin.MetaTube/Providers/MovieProvider.cs
+++ b/Jellyfin.Plugin.MetaTube/Providers/MovieProvider.cs
@@ -51,9 +51,9 @@ public class MovieProvider : BaseProvider, IRemoteMetadataProvider<Movie, MovieI
         var pid = info.GetPid(Plugin.ProviderId);
         if (string.IsNullOrWhiteSpace(pid.Id) || string.IsNullOrWhiteSpace(pid.Provider))
         {
-            // Search movies and pick the first result.
-            var firstResult = (await GetSearchResults(info, cancellationToken)).FirstOrDefault();
-            if (firstResult != null) pid = firstResult.GetPid(Plugin.ProviderId);
+            // Search movies and pick the result whose catalog number actually matches.
+            var bestResult = PickBestResult(await GetSearchResults(info, cancellationToken), info.Name);
+            if (bestResult != null) pid = bestResult.GetPid(Plugin.ProviderId);
         }
 
         // Nothing matched (e.g. a .strm file whose name carries no resolvable ID,
@@ -283,6 +283,45 @@ public class MovieProvider : BaseProvider, IRemoteMetadataProvider<Movie, MovieI
         }
 
         return results;
+    }
+
+    /// <summary>
+    /// Extracts the leading catalog number for comparison, e.g. "SSIS-462-UC" -> "SSIS462".
+    /// </summary>
+    private static string ExtractCatalogNumber(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) return null;
+        var m = Regex.Match(name, @"[A-Za-z]{2,8}[-_]?\d{2,6}");
+        if (!m.Success) return null;
+        return Regex.Replace(m.Value.ToUpperInvariant(), "[^A-Z0-9]", string.Empty);
+    }
+
+    /// <summary>
+    /// Picks the search result whose catalog number matches the query. Taking the first
+    /// result blindly can bind an unrelated movie (e.g. a DUGA item) to a JavBus number,
+    /// which then yields wrong metadata AND a wrong cover image.
+    /// </summary>
+    private RemoteSearchResult PickBestResult(IEnumerable<RemoteSearchResult> results, string query)
+    {
+        var list = results?.Where(r => r != null).ToList() ?? new List<RemoteSearchResult>();
+        if (list.Count == 0) return null;
+
+        var expected = ExtractCatalogNumber(query);
+        if (string.IsNullOrEmpty(expected)) return list[0];
+
+        foreach (var r in list)
+        {
+            // Search result name is formatted as "[Provider] NUMBER Title".
+            var m = Regex.Match(r.Name ?? string.Empty, @"^\[[^\]]+\]\s*(\S+)");
+            if (!m.Success) continue;
+            var actual = Regex.Replace(m.Groups[1].Value.ToUpperInvariant(), "[^A-Z0-9]", string.Empty);
+            if (string.IsNullOrEmpty(actual)) continue;
+            if (actual == expected || actual.StartsWith(expected)) return r;
+        }
+
+        Logger.Warn("No search result matches catalog number {0} for \"{1}\", skip to avoid wrong metadata/image",
+            expected, query);
+        return null;
     }
 
     private static IEnumerable<string> GetSearchCandidates(string name)

--- a/Jellyfin.Plugin.MetaTube/Providers/MovieProvider.cs
+++ b/Jellyfin.Plugin.MetaTube/Providers/MovieProvider.cs
@@ -56,6 +56,15 @@ public class MovieProvider : BaseProvider, IRemoteMetadataProvider<Movie, MovieI
             if (firstResult != null) pid = firstResult.GetPid(Plugin.ProviderId);
         }
 
+        // Nothing matched (e.g. a .strm file whose name carries no resolvable ID,
+        // or a custom video with no catalog number). Skip gracefully instead of
+        // calling the info API with empty provider/id and throwing a 404.
+        if (string.IsNullOrWhiteSpace(pid.Id) || string.IsNullOrWhiteSpace(pid.Provider))
+        {
+            Logger.Warn("Movie not found, skip metadata: {0}", info.Name);
+            return new MetadataResult<Movie> { HasMetadata = false };
+        }
+
         Logger.Info("Get movie info: {0}", pid.ToString());
 
         var m = await ApiClient.GetMovieInfoAsync(pid.Provider, pid.Id, cancellationToken);
@@ -205,9 +214,27 @@ public class MovieProvider : BaseProvider, IRemoteMetadataProvider<Movie, MovieI
         var searchResults = new List<MovieSearchResult>();
         if (string.IsNullOrWhiteSpace(pid.Id) || string.IsNullOrWhiteSpace(pid.Provider))
         {
-            // Search movie by name.
-            Logger.Info("Search for movie: {0}", info.Name);
-            searchResults.AddRange(await ApiClient.SearchMovieAsync(info.Name, pid.Provider, cancellationToken));
+            // Search movie by name. Try the original name first, then progressively
+            // normalized variants (strip uncensored/variant suffixes and Chinese tokens,
+            // finally the leading catalog number) so that .strm files with messy names
+            // like "OFJE-550-D" or "FSDSS-789_深田えいみ_无码破解" can still match.
+            foreach (var query in GetSearchCandidates(info.Name))
+            {
+                Logger.Info("Search for movie: {0}", query);
+                try
+                {
+                    var matched = await ApiClient.SearchMovieAsync(query, pid.Provider, cancellationToken);
+                    if (matched != null && matched.Any())
+                    {
+                        searchResults.AddRange(matched);
+                        break;
+                    }
+                }
+                catch (Exception e)
+                {
+                    Logger.Warn("Search failed for movie: {0} ({1})", query, e.Message);
+                }
+            }
         }
         else
         {
@@ -256,6 +283,26 @@ public class MovieProvider : BaseProvider, IRemoteMetadataProvider<Movie, MovieI
         }
 
         return results;
+    }
+
+    private static IEnumerable<string> GetSearchCandidates(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name)) yield break;
+
+        // Original query first - never degrade a working match.
+        yield return name;
+
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { name };
+
+        // Strip trailing uncensored / variant markers and Chinese suffix tokens.
+        var s = Regex.Replace(name,
+            @"[_\-]?(UC|UCS|CR|CRB|UCF|C|F|D|B|U|无码破解|无码|破解|流出|无修正|中文字幕|中文|无码流出)$",
+            string.Empty, RegexOptions.IgnoreCase);
+        if (seen.Add(s)) yield return s;
+
+        // Fall back to the leading catalog number (e.g. FSDSS-789, SSNI-591, ABP001).
+        var m = Regex.Match(name, @"^[A-Za-z]{2,8}[-]?\d{2,6}", RegexOptions.IgnoreCase);
+        if (m.Success && seen.Add(m.Value)) yield return m.Value;
     }
 
     private async Task SetActorImageUrl(PersonInfo actor, CancellationToken cancellationToken)

--- a/Jellyfin.Plugin.MetaTube/Providers/MovieProvider.cs
+++ b/Jellyfin.Plugin.MetaTube/Providers/MovieProvider.cs
@@ -215,9 +215,9 @@ public class MovieProvider : BaseProvider, IRemoteMetadataProvider<Movie, MovieI
         if (string.IsNullOrWhiteSpace(pid.Id) || string.IsNullOrWhiteSpace(pid.Provider))
         {
             // Search movie by name. Try the original name first, then progressively
-            // normalized variants (strip uncensored/variant suffixes and Chinese tokens,
-            // finally the leading catalog number) so that .strm files with messy names
-            // like "OFJE-550-D" or "FSDSS-789_深田えいみ_无码破解" can still match.
+            // normalized variants (strip trailing variant markers and CJK labels,
+            // finally the leading identifier) so that .strm files with decorated
+            // names can still match.
             foreach (var query in GetSearchCandidates(info.Name))
             {
                 Logger.Info("Search for movie: {0}", query);
@@ -286,7 +286,7 @@ public class MovieProvider : BaseProvider, IRemoteMetadataProvider<Movie, MovieI
     }
 
     /// <summary>
-    /// Extracts the leading catalog number for comparison, e.g. "SSIS-462-UC" -> "SSIS462".
+    /// Extracts the leading identifier for comparison, e.g. "ABC-123-UC" -> "ABC123".
     /// </summary>
     private static string ExtractCatalogNumber(string name)
     {
@@ -297,9 +297,9 @@ public class MovieProvider : BaseProvider, IRemoteMetadataProvider<Movie, MovieI
     }
 
     /// <summary>
-    /// Picks the search result whose catalog number matches the query. Taking the first
-    /// result blindly can bind an unrelated movie (e.g. a DUGA item) to a JavBus number,
-    /// which then yields wrong metadata AND a wrong cover image.
+    /// Picks the search result whose identifier matches the query. Taking the first
+    /// result blindly can bind an unrelated movie to the requested identifier, which
+    /// then yields wrong metadata AND a wrong cover image.
     /// </summary>
     private RemoteSearchResult PickBestResult(IEnumerable<RemoteSearchResult> results, string query)
     {
@@ -333,13 +333,13 @@ public class MovieProvider : BaseProvider, IRemoteMetadataProvider<Movie, MovieI
 
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { name };
 
-        // Strip trailing uncensored / variant markers and Chinese suffix tokens.
-        var s = Regex.Replace(name,
-            @"[_\-]?(UC|UCS|CR|CRB|UCF|C|F|D|B|U|无码破解|无码|破解|流出|无修正|中文字幕|中文|无码流出)$",
-            string.Empty, RegexOptions.IgnoreCase);
-        if (seen.Add(s)) yield return s;
+        // Strip a trailing variant marker (e.g. "-UC", "-D") and any trailing CJK label,
+        // so decorated file names still reach the base identifier.
+        var s = Regex.Replace(name, @"[_\-]?[A-Za-z]{1,3}$", string.Empty);
+        s = Regex.Replace(s, @"[_\-]?[一-鿿]+$", string.Empty);
+        if (!string.IsNullOrWhiteSpace(s) && seen.Add(s)) yield return s;
 
-        // Fall back to the leading catalog number (e.g. FSDSS-789, SSNI-591, ABP001).
+        // Fall back to the leading identifier (letters + optional dash + digits).
         var m = Regex.Match(name, @"^[A-Za-z]{2,8}[-]?\d{2,6}", RegexOptions.IgnoreCase);
         if (m.Success && seen.Add(m.Value)) yield return m.Value;
     }

--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ MetaTube Plugin for Jellyfin/Emby.
 - Face Detection: Cut primary image with face centered by face detection engine.
 - Auto Translation: Support translate certain metadata to preferred language.
 
+## Fork changes: `.strm` scraping
+
+This fork improves metadata scraping for libraries built from `.strm` files:
+
+- **Graceful handling of unmatched items**: a "not found" response from the metadata API no longer
+  aborts the whole refresh. Items without a resolvable identifier are skipped quietly instead of
+  raising an error.
+- **Normalized search retry**: when the exact file name yields nothing, the search is retried with
+  normalized variants (trailing variant markers and trailing CJK labels removed, then the leading
+  identifier only). The original name is always tried first and is never degraded.
+- **Identifier verification**: a search result is only accepted when its identifier matches the one
+  parsed from the file name. Previously the first result was taken blindly, which could bind an
+  unrelated entry to the item — producing wrong metadata *and* a wrong cover image, since image URLs
+  are built from the stored provider id.
+
+Only `Jellyfin.Plugin.MetaTube/Providers/MovieProvider.cs` is modified; the change is shared by both
+the Jellyfin and Emby build targets.
+
 ## Platforms
 
 [![Jellyfin](https://img.shields.io/static/v1?color=%2300A4DC&style=for-the-badge&label=Jellyfin&logo=jellyfin&message=10.11.x)](https://jellyfin.org/)

--- a/README.md
+++ b/README.md
@@ -54,8 +54,12 @@ This fork improves metadata scraping for libraries built from `.strm` files:
   unrelated entry to the item — producing wrong metadata *and* a wrong cover image, since image URLs
   are built from the stored provider id.
 
-Only `Jellyfin.Plugin.MetaTube/Providers/MovieProvider.cs` is modified; the change is shared by both
-the Jellyfin and Emby build targets.
+- **Images survive a failing detail request**: `Primary`, `Thumb` and `Backdrop` URLs are built from
+  the stored provider id, so they stay available even when the metadata detail request fails. One
+  unreachable upstream source no longer strips an item of all its artwork.
+
+Only `Providers/MovieProvider.cs` and `Providers/MovieImageProvider.cs` are modified; both changes
+are shared by the Jellyfin and Emby build targets.
 
 ## Platforms
 


### PR DESCRIPTION
## Summary

Improves scraping for libraries built from `.strm` files. Three problems are addressed, all observed in real Emby logs:

1. A "not found" response from the MetaTube API was treated as a fatal exception, so `.strm` files whose names carry no resolvable identifier aborted the whole metadata refresh with `Error in MetaTube`.
2. Search results were accepted blindly (`FirstOrDefault()`), so an unrelated entry could be bound to the item. Since `MovieImageProvider` builds image URLs from the stored provider id (`/v1/images/{type}/{provider}/{id}`), a wrong id means the item silently gets **another title's cover image**.
3. `MovieImageProvider.GetImages` fetched the metadata detail first, so a single unreachable upstream source (e.g. a 500 from one provider) discarded **all** images of an item — even though Primary/Thumb/Backdrop URLs only need provider/id.

## Changes

`Jellyfin.Plugin.MetaTube/Providers/MovieProvider.cs` (shared by both targets, no `__EMBY__` guard needed):

- **`GetMetadata`**: return `HasMetadata = false` when no provider/id resolves, instead of calling the info API with empty provider/id and throwing a 404.
- **`GetSearchResults`**: wrap the search call in try/catch; a 404 now logs a warning instead of crashing the refresh.
- **`GetSearchCandidates`** (new): retry the search with normalized variants of the file name — trailing variant markers (`-UC`, `-D`, ...) and trailing CJK labels stripped, then the leading identifier only. The original name is always tried first, is never degraded, and the first hit wins.
- **`PickBestResult` / `ExtractCatalogNumber`** (new): only accept a search result whose `[Provider] NUMBER` matches the identifier parsed from the query. If nothing matches, the item is skipped with a warning, so no wrong metadata/cover is attached.

`Jellyfin.Plugin.MetaTube/Providers/MovieImageProvider.cs`:

- Build `Primary`, `Thumb` and `Backdrop` from the stored provider id, so they survive a failing detail request.
- Move the detail request (used only for extra preview images) into a try/catch: it now logs a warning instead of stripping the item of all artwork.

`README.md`: documents the behavior above in a "Fork changes: `.strm` scraping" section.

## Why the identifier check matters

Observed in a real Emby log (`ProviderManager: Saving image to ...`), the same source image was written into two different movies' folders, because both items had been bound to the same wrong provider id. After this change such a result is rejected, and the item is left unmatched rather than silently mislabeled.

## Notes

- Behavior for correctly matching names is unchanged: the original name is always queried first, and normalization only kicks in when that returns nothing.
- `bin/` is already gitignored; only the two provider files and the README are modified.
- Built and verified against the Emby target (`dotnet build -c Release.Emby`, net8.0, 0 warnings / 0 errors). The Jellyfin target targets .NET 9 and could not be compiled locally (only the .NET 8 SDK is installed here), but the change is shared, unconditional code with no target-specific API.
